### PR TITLE
Support parsing of DLT network traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2024-08-16
+### Added
+- Support parsing of DLT network traces
+
 ## [0.14.4] - 2023-07-21
 ### Changed
 - Updated quick-xml library and dependencies
+
 ## [0.14.2] - 2022-11-02
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dlt-core"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["esrlabs.com"]
 edition = "2021"
 description = """
@@ -27,6 +27,10 @@ thiserror = "1.0"
 [features]
 default = []
 statistics = [ "buf_redux" ]
+debug_parser = []
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }

--- a/src/tests/fibex_tests.rs
+++ b/src/tests/fibex_tests.rs
@@ -306,4 +306,14 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn test_fibex_robustness() {
+        let fibex = read_fibexes(vec![
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/robustness.xml")
+        ])
+        .expect("can't parse fibex");
+
+        println!("{:?}", fibex);
+    }
 }

--- a/tests/robustness.xml
+++ b/tests/robustness.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fx:FIBEX xmlns:ho="http://www.asam.net/xml" xmlns:fx="http://www.asam.net/xml/fbx">
+    <fx:PROJECT ID="Project">
+        <ho:SHORT-NAME>ProjectName</ho:SHORT-NAME>
+    </fx:PROJECT>
+    <fx:ELEMENTS>
+        <fx:PDUS>
+
+            <!-- A PDU without description should not break FIBEX parsing -->
+            <fx:PDU ID="ID_PDU_01">
+                <ho:SHORT-NAME>ID_PDU_01</ho:SHORT-NAME>
+                <ho:DESC></ho:DESC>
+                <fx:BYTE-LENGTH>0</fx:BYTE-LENGTH>
+                <fx:PDU-TYPE>OTHER</fx:PDU-TYPE>
+            </fx:PDU>
+
+        </fx:PDUS>
+
+    </fx:ELEMENTS>
+        <fx:PROCESSING-INFORMATION>
+            <fx:CODINGS>
+
+                <!-- Codings should not break FIBEX parsing -->
+                <fx:CODING ID="ID_CODING_01">
+                    <ho:SHORT-NAME>ID_CODING_01</ho:SHORT-NAME>
+                    <ho:CODED-TYPE ho:BASE-DATA-TYPE="A_UINT8" CATEGORY="STANDARD-LENGTH-TYPE"/>
+                </fx:CODING>
+                
+            </fx:CODINGS>
+        </fx:PROCESSING-INFORMATION>
+</fx:FIBEX>
+


### PR DESCRIPTION
- Add robustness to parsing Fibex files containing non-DLT protocoll descriptions (eg. SOME/IP).
- Add PayloadContent::NetworkTrace for returning raw bytes of network trace payload arguments.