### PR TITLE
Cleanup for version 0.16 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support parsing of DLT network traces
 
+## [0.15.0] - 2024-05-03
+### Changed
+- Made dlt-statistics a separate feature
+
 ## [0.14.4] - 2023-07-21
 ### Changed
 - Updated quick-xml library and dependencies

--- a/src/filtering.rs
+++ b/src/filtering.rs
@@ -49,6 +49,7 @@ pub struct DltFilterConfig {
 }
 
 /// A processed version of the filter configuration that can be used to parse dlt.
+///
 /// When a `DltFilterConfig` is received (e.g. as serialized json), this can easily
 /// be converted into this processed version using `filter_config.into()`
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Cleanup for version 0.16 release

- Added missing change-log docu for previous version 0.15
- Fixed clippy warning on too long first doc paragraph