### PR TITLE
Remove `nom` crate types from the return types of parsing functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2024-10-04
+### Changed
+- breaking change in API: Remove `nom` crate types from the return types of parsing functions. 
+
 ## [0.16.0] - 2024-08-16
 ### Added
 - Support parsing of DLT network traces

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dlt-core"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["esrlabs.com"]
 edition = "2021"
 description = """

--- a/src/tests/dlt_parse_tests.rs
+++ b/src/tests/dlt_parse_tests.rs
@@ -853,16 +853,16 @@ mod tests {
     fn test_dlt_zero_terminated_string_exact() {
         let mut buf = BytesMut::with_capacity(4);
         buf.extend_from_slice(b"id42");
-        let res: IResult<&[u8], &str, DltParseError> = dlt_zero_terminated_string(&buf, 4);
-        let expected: IResult<&[u8], &str, DltParseError> = Ok((&[], "id42"));
+        let res = dlt_zero_terminated_string(&buf, 4);
+        let expected: Result<(&[u8], &str), DltParseError> = Ok((&[], "id42"));
         assert_eq!(expected, res);
     }
     #[test]
     fn test_dlt_zero_terminated_string_more_data() {
         let mut buf = BytesMut::with_capacity(6);
         buf.extend_from_slice(b"id42++");
-        let res: IResult<&[u8], &str, DltParseError> = dlt_zero_terminated_string(&buf, 4);
-        let expected: IResult<&[u8], &str, DltParseError> = Ok((b"++", "id42"));
+        let res = dlt_zero_terminated_string(&buf, 4);
+        let expected: Result<(&[u8], &str), DltParseError> = Ok((b"++", "id42"));
         assert_eq!(expected, res);
     }
     #[test]
@@ -871,20 +871,20 @@ mod tests {
         buf.extend_from_slice(b"id\0");
         assert!(matches!(
             dlt_zero_terminated_string(&buf, 4),
-            Err(nom::Err::Incomplete(nom::Needed::Size(_)))
+            Err(DltParseError::IncompleteParse { .. })
         ));
         buf.clear();
         buf.extend_from_slice(b"id\0\0");
-        let expected: IResult<&[u8], &str, DltParseError> = Ok((b"", "id"));
+        let expected: Result<(&[u8], &str), DltParseError> = Ok((b"", "id"));
         assert_eq!(expected, dlt_zero_terminated_string(&buf, 4));
     }
     #[test]
     fn test_dlt_zero_terminated_string_early_terminated() {
         let mut buf = BytesMut::with_capacity(4);
         buf.extend_from_slice(b"id4\0somethingelse");
-        let res: IResult<&[u8], &str, DltParseError> = dlt_zero_terminated_string(&buf, 4);
+        let res = dlt_zero_terminated_string(&buf, 4);
         trace!("res : {:?}", res);
-        let expected: IResult<&[u8], &str, DltParseError> = Ok((b"somethingelse", "id4"));
+        let expected: Result<(&[u8], &str), DltParseError> = Ok((b"somethingelse", "id4"));
         assert_eq!(expected, res);
     }
     #[test]
@@ -892,8 +892,8 @@ mod tests {
         let mut buf = BytesMut::with_capacity(4);
         let broken = vec![0x41, 0, 146, 150];
         buf.extend_from_slice(&broken);
-        let res: IResult<&[u8], &str, DltParseError> = dlt_zero_terminated_string(&buf, 4);
-        let expected: IResult<&[u8], &str, DltParseError> = Ok((b"", "A"));
+        let res = dlt_zero_terminated_string(&buf, 4);
+        let expected: Result<(&[u8], &str), DltParseError> = Ok((b"", "A"));
         assert_eq!(expected, res);
     }
 }


### PR DESCRIPTION
This PR will introduce breaking changes to the public API

It removes all the types from the crate `nom` in the return types of functions in parsing module.

This will avoid any potential breaking changes on this crate when updating `nom` dependency if they introduce any breaking changes on their types.

Unit tests have been adjusted accordingly.

I've increased the version number of the crate and updated the change log as well.