### PR TITLE
Up to 0.18.0 (added feature "serde-support")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2024-12-18
+### Changed
+- Add feature "serde-support", which adds to crate's types Serialize/Deserialize
+
 ## [0.17.0] - 2024-10-04
 ### Changed
 - breaking change in API: Remove `nom` crate types from the return types of parsing functions. 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dlt-core"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["esrlabs.com"]
 edition = "2021"
 description = """
@@ -20,14 +20,18 @@ memchr = "2.4"
 nom = "7.1"
 quick-xml = "0.29"
 rustc-hash = "1.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }
 thiserror = "1.0"
 
 [features]
 default = []
 statistics = [ "buf_redux" ]
 debug_parser = []
+serde-support = [
+    "serde",
+    "serde_json"
+]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
@@ -37,8 +41,8 @@ criterion = { version = "0.4", features = ["html_reports"] }
 dirs = "4.0"
 env_logger = "0.10"
 pretty_assertions = "1.3"
-proptest = "1.0"
-proptest-derive = "0.3"
+proptest = "1.6"
+proptest-derive = "0.5"
 
 [[bench]]
 name = "dlt_benchmarks"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A library that support efficient parsing & writing log-messages encoded as `Diagnositic` `Log` and `Trace` messages.
 
-## Features
+## Features / Functionality
 
 * compliant with the official Autosar DLT specification
 * efficiently parse binary DLT content
@@ -18,7 +18,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-dlt_core = "0.17"
+dlt_core = "0.18"
 ```
 
 This is an example of how to parse a message and serialize it back to a byte array.
@@ -130,3 +130,13 @@ fn main() {
 empty content after 33554430 parsed messages
 parsing 33554430 messages took 37.015s! (133.773 MB/s)
 ```
+
+Below is the revised and improved English version of the documentation:
+
+## Crate's Features
+
+- **`statistics`**: Enables the `statistics` module, which scans the source data and provides a summary of its contents. This gives you an overview of the number of messages and their content.
+
+- **`debug_parser`**: Adds additional log output for debugging purposes.
+
+- **`serde-support`**: Adds `Serialize` and `Deserialize` implementations (via `serde`) to all public types. This feature is useful if you need to encode or decode these types for transmission or storage.

--- a/src/dlt.rs
+++ b/src/dlt.rs
@@ -17,7 +17,6 @@
 
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use bytes::{BufMut, BytesMut};
-use serde::Serialize;
 use std::{convert::TryFrom, str};
 use thiserror::Error;
 
@@ -40,7 +39,11 @@ pub enum Error {
 }
 
 /// Used to express the byte order of DLT data type fields
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub enum Endianness {
     /// Little Endian
@@ -50,7 +53,11 @@ pub enum Endianness {
 }
 
 /// represents a DLT message including all headers
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Message {
     pub storage_header: Option<StorageHeader>,
     pub header: StandardHeader,
@@ -59,7 +66,11 @@ pub struct Message {
 }
 
 /// Add some stupid docs
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct StorageHeader {
     pub timestamp: DltTimeStamp,
@@ -68,7 +79,11 @@ pub struct StorageHeader {
 }
 
 /// The Standard Header shall be in big endian format
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct StandardHeader {
     pub version: u8,
     pub endianness: Endianness,
@@ -89,7 +104,11 @@ pub struct StandardHeader {
 /// The Dlt Extended Header is directly attached after the Dlt Standard Header fields.
 ///
 /// The Extended Header shall be in big endian format
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct ExtendedHeader {
     pub verbose: bool,
@@ -122,7 +141,11 @@ pub struct ExtendedHeader {
 /// Control messages are normal Dlt messages with a Standard Header, an Extended Header,
 /// and payload. The payload contains of the Service ID and the contained parameters.
 ///
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub enum PayloadContent {
     #[cfg_attr(
@@ -151,7 +174,11 @@ pub enum PayloadContent {
     NetworkTrace(Vec<Vec<u8>>),
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct DltTimeStamp {
     pub seconds: u32,
@@ -313,7 +340,11 @@ impl StandardHeader {
 }
 
 /// Representation of log levels used in DLT log messages
-#[derive(Debug, PartialEq, PartialOrd, Clone, Copy, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub enum LogLevel {
     Fatal,
@@ -344,7 +375,11 @@ impl AsRef<str> for LogLevel {
 ///
 /// In case the dlt message contains tracing information, the Trace-Type
 /// indicates different kinds of trace message types
-#[derive(Debug, PartialEq, Clone, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub enum ApplicationTraceType {
     Variable,
@@ -376,7 +411,11 @@ impl AsRef<str> for ApplicationTraceType {
 ///
 /// In case the dlt message contains networking information,
 /// the Trace-Type indicates different kinds of network message types
-#[derive(Debug, PartialEq, Clone, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub enum NetworkTraceType {
     Ipc,
@@ -415,7 +454,11 @@ const CTRL_TYPE_RESPONSE: u8 = 0x2;
 ///
 /// In case the dlt message contains control information,
 /// the Trace-Type indicates different kinds of control message types
-#[derive(Debug, PartialEq, Clone, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub enum ControlType {
     Request,  // represented by 0x1
@@ -452,7 +495,11 @@ impl ControlType {
 }
 
 /// Part of the extended header, distinguishes log, trace and controll messages
-#[derive(Debug, PartialEq, Clone, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub enum MessageType {
     Log(LogLevel),
@@ -509,7 +556,11 @@ impl ExtendedHeader {
 
 /// Fixed-Point representation. only supports 32 bit and 64 bit values
 /// according to the spec 128 bit are possible but we don't support it
-#[derive(Debug, PartialEq, Clone, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub enum FixedPointValue {
     I32(i32),
@@ -524,7 +575,11 @@ pub(crate) fn fixed_point_value_width(v: &FixedPointValue) -> usize {
 }
 
 /// Represents the value of an DLT argument
-#[derive(Debug, PartialEq, Clone, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Value {
     Bool(u8),
     U8(u8),
@@ -545,7 +600,11 @@ pub enum Value {
 
 /// Defines what string type is used, `ASCII` or `UTF8`
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub enum StringCoding {
     ASCII,
@@ -558,7 +617,11 @@ pub enum StringCoding {
 }
 
 /// Represents the bit width of a floatingpoint value type
-#[derive(Debug, Clone, PartialEq, Copy, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone, PartialEq, Copy)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub enum FloatWidth {
     Width32 = 32,
@@ -573,7 +636,11 @@ pub(crate) fn float_width_to_type_length(width: FloatWidth) -> TypeLength {
 }
 
 /// Represents the bit width of a value type
-#[derive(Debug, Clone, PartialEq, Copy, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone, PartialEq, Copy)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub enum TypeLength {
     BitLength8 = 8,
@@ -607,7 +674,11 @@ impl TypeLength {
 /// Part of the TypeInfo that specifies what kind of type is encoded
 ///
 /// the Array type is not yet supported and honestly I never saw anyone using it
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub enum TypeInfoKind {
     Bool,
@@ -650,7 +721,11 @@ pub enum TypeInfoKind {
 /// field with the text (of name or unit). The length field contains the
 /// number of characters of the associated name or unit filed. The unit
 /// information is to add only in some data types.
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct TypeInfo {
     pub kind: TypeInfoKind,
@@ -832,7 +907,11 @@ impl TryFrom<u32> for TypeInfo {
 ///     * i32 bit if Type Length (TYLE) equals 1,2 or 3
 ///     * i64 bit if Type Length (TYLE) equals 4
 ///     * i128 bit if Type Length (TYLE) equals 5 (unsupported)
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FixedPoint {
     pub quantization: f32,
     pub offset: FixedPointValue,
@@ -845,7 +924,11 @@ pub struct FixedPoint {
 /// information of an application). In addition to the variable value
 /// itself, it is needed to provide information like size and type
 /// of the variable. This information is contained in the `type_info` field.
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Argument {
     pub type_info: TypeInfo,
     pub name: Option<String>,
@@ -1442,7 +1525,11 @@ fn payload_content_len(content: &PayloadContent) -> usize {
 }
 
 /// Configuration options for the extended header
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ExtendedHeaderConfig {
     pub message_type: MessageType,
     pub app_id: String,
@@ -1450,7 +1537,11 @@ pub struct ExtendedHeaderConfig {
 }
 
 /// Configuration options for a DLT message, used when constructing a message
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct MessageConfig {
     pub version: u8,
     pub counter: u8,

--- a/src/dlt.rs
+++ b/src/dlt.rs
@@ -65,7 +65,7 @@ pub struct Message {
     pub payload: PayloadContent,
 }
 
-/// Add some stupid docs
+/// Storage header is used in case of dlt entries stored in file
 #[cfg_attr(
     feature = "serde-support",
     derive(serde::Serialize, serde::Deserialize)

--- a/src/fibex.rs
+++ b/src/fibex.rs
@@ -22,7 +22,6 @@ use quick_xml::{
     },
     Reader as XmlReader,
 };
-use serde::{Deserialize, Serialize};
 use std::{
     collections::{hash_map::Entry, HashMap},
     fs::File,
@@ -53,7 +52,11 @@ pub enum Error {
 }
 
 /// Contains all the paths of fibex files that should be combined into the model
-#[derive(Serialize, Deserialize, Debug)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug)]
 pub struct FibexConfig {
     pub fibex_file_paths: Vec<String>,
 }

--- a/src/filtering.rs
+++ b/src/filtering.rs
@@ -94,10 +94,13 @@ impl From<&DltFilterConfig> for ProcessedDltFilterConfig {
     }
 }
 
-// /// Read filter config from a json file
-// pub fn read_filter_options(f: &mut fs::File) -> Option<DltFilterConfig> {
-//     let mut contents = String::new();
-//     f.read_to_string(&mut contents)
-//         .ok()
-//         .and_then(|_| serde_json::from_str(&contents[..]).ok())
-// }
+/// Read filter config from a json file. Available only with feature "serde-support"
+#[cfg(feature = "serde-support")]
+pub fn read_filter_options(f: &mut std::fs::File) -> Option<DltFilterConfig> {
+    use std::io::Read;
+
+    let mut contents = String::new();
+    f.read_to_string(&mut contents)
+        .ok()
+        .and_then(|_| serde_json::from_str(&contents[..]).ok())
+}

--- a/src/filtering.rs
+++ b/src/filtering.rs
@@ -12,8 +12,7 @@
 
 //! # filter definitions for filtering dlt messages
 use crate::dlt;
-use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, fs, io::Read, iter::FromIterator};
+use std::{collections::HashSet, iter::FromIterator};
 
 /// Describes what DLT message to filter out based on log-level and app/ecu/context-id
 ///
@@ -23,7 +22,11 @@ use std::{collections::HashSet, fs, io::Read, iter::FromIterator};
 ///
 /// only this is possible:
 /// - `app-id is_one_of ["abc","foo"] AND log-level <= DEBUG`
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone)]
 pub struct DltFilterConfig {
     /// only select log entries with level MIN_LEVEL and more severe
     ///
@@ -91,10 +94,10 @@ impl From<&DltFilterConfig> for ProcessedDltFilterConfig {
     }
 }
 
-/// Read filter config from a json file
-pub fn read_filter_options(f: &mut fs::File) -> Option<DltFilterConfig> {
-    let mut contents = String::new();
-    f.read_to_string(&mut contents)
-        .ok()
-        .and_then(|_| serde_json::from_str(&contents[..]).ok())
-}
+// /// Read filter config from a json file
+// pub fn read_filter_options(f: &mut fs::File) -> Option<DltFilterConfig> {
+//     let mut contents = String::new();
+//     f.read_to_string(&mut contents)
+//         .ok()
+//         .and_then(|_| serde_json::from_str(&contents[..]).ok())
+// }

--- a/src/proptest_strategies.rs
+++ b/src/proptest_strategies.rs
@@ -199,15 +199,14 @@ fn fp_strategy(width: FloatWidth) -> impl Strategy<Value = FixedPoint> {
     })
 }
 
+type StrategyOut = (
+    TypeInfo,
+    Option<FixedPoint>,
+    Value,
+    (Option<String>, Option<String>),
+);
 // strategy that produces TypeInfo and matching optional FixedPoint for arguments
-fn type_info_and_fixed_point_strategy() -> impl Strategy<
-    Value = (
-        TypeInfo,
-        Option<FixedPoint>,
-        Value,
-        (Option<String>, Option<String>),
-    ),
-> {
+fn type_info_and_fixed_point_strategy() -> impl Strategy<Value = StrategyOut> {
     any::<TypeInfo>().prop_flat_map(move |ti| {
         let fp_strat = match ti.kind {
             TypeInfoKind::SignedFixedPoint(width) => fp_strategy(width).prop_map(Some).boxed(),

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -21,7 +21,6 @@ use crate::{
 use buf_redux::{policy::MinBuffered, BufReader as ReduxReader};
 use nom::bytes::streaming::take;
 use rustc_hash::FxHashMap;
-use serde::Serialize;
 use std::{
     fs,
     io::{BufRead, Read},
@@ -91,7 +90,11 @@ pub fn dlt_statistic_row_info(
 }
 
 /// Shows how many messages per log level where found
-#[derive(Serialize, Debug, Default, Clone)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Default, Clone)]
 pub struct LevelDistribution {
     pub non_log: usize,
     pub log_fatal: usize,
@@ -158,7 +161,11 @@ type IdMap = FxHashMap<String, LevelDistribution>;
 
 /// Includes the `LevelDistribution` for all `app-ids`, `context-ids` and
 /// `ecu_ids`
-#[derive(Serialize, Debug)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug)]
 pub struct StatisticInfo {
     pub app_ids: Vec<(String, LevelDistribution)>,
     pub context_ids: Vec<(String, LevelDistribution)>,
@@ -205,7 +212,11 @@ impl Default for StatisticInfo {
 }
 
 /// Stats about a row in a DLT file
-#[derive(Serialize, Debug)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug)]
 pub struct StatisticRowInfo {
     pub app_id_context_id: Option<(String, String)>,
     pub ecu_id: Option<String>,


### PR DESCRIPTION
- Upgrade versions of some outdated dev-dependencies
- Exclude `Serialize` and `Deserialize` into feature `serde-support`
- Resolve clippy warnings