### PR TITLE
Make fibex parsing a feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2025-02-06
+### Changed
+- Made fibex parsing a separate feature
+
 ## [0.18.1] - 2025-01-31
 ### Changed
 - Cleanup license headers (GH-issue #13)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dlt-core"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["esrlabs.com"]
 edition = "2021"
 description = """
@@ -13,13 +13,10 @@ repository = "https://github.com/esrlabs/dlt-core"
 buf_redux = { version = "0.8.4", optional = true }
 byteorder = "1.4"
 bytes = "1.0"
-derive_more = "0.99.13"
-lazy_static = "1.4"
 log = "0.4"
 memchr = "2.4"
 nom = "7.1"
-quick-xml = "0.29"
-rustc-hash = "1.1"
+quick-xml = { version = "0.29", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 thiserror = "1.0"
@@ -27,6 +24,7 @@ thiserror = "1.0"
 [features]
 default = []
 statistics = [ "buf_redux" ]
+fibex_parser = [ "quick-xml" ]
 debug_parser = []
 serde-support = [
     "serde",

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Below is the revised and improved English version of the documentation:
 
 - **`statistics`**: Enables the `statistics` module, which scans the source data and provides a summary of its contents. This gives you an overview of the number of messages and their content.
 
+- **`fibex_parser`**: Enables the `fibex` module, which allows to parse configurations for non-verbose messages from a fibex model.
+
 - **`debug_parser`**: Adds additional log output for debugging purposes.
 
 - **`serde-support`**: Adds `Serialize` and `Deserialize` implementations (via `serde`) to all public types. This feature is useful if you need to encode or decode these types for transmission or storage.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 extern crate log;
 
 pub mod dlt;
+#[cfg(feature = "fibex_parser")]
 pub mod fibex;
 pub mod filtering;
 pub mod parse;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -14,6 +14,7 @@
 #[macro_use]
 mod dlt_tests;
 mod dlt_parse_tests;
+#[cfg(feature = "fibex_parser")]
 mod fibex_tests;
 #[cfg(feature = "statistics")]
 mod statistics_tests;


### PR DESCRIPTION
This PR moves the fibex parsing into a separate feature.
Updates Version to: 0.19.0